### PR TITLE
Ignore ramdisks while checking hdd | ssd

### DIFF
--- a/src/Sparrow.Server/LowMemory/CheckPageFileOnHdd.cs
+++ b/src/Sparrow.Server/LowMemory/CheckPageFileOnHdd.cs
@@ -421,6 +421,8 @@ namespace Sparrow.Server.LowMemory
                     HashSet<string> disks = KernelVirtualFileSystemUtils.GetAllDisksFromPartitionsFile();
                     foreach (var disk in disks)
                     {
+                        //ignore ramdisks (ram0..ram15 etc)
+                        if (disk.Equals("ram", StringComparison.OrdinalIgnoreCase)) continue;
                         var filename = $"/sys/block/{disk}/queue/rotational";
                         var isHdd = KernelVirtualFileSystemUtils.ReadNumberFromFile(filename);
                         if (isHdd == 0)


### PR DESCRIPTION
Newer versions of Linux show ramdisks (ram0..ram15 etc) in /proc/partitions. We just ignore these.